### PR TITLE
Add xUnit test project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Barcode.Generator
 .NET Standard Library based on ZXing.NET project that produce in memory BMP images of generated barcodes
+
+## Running tests
+
+To run the unit tests execute:
+
+```bash
+dotnet test
+```

--- a/src/Barcode.Generator.Tests/Barcode.Generator.Tests.csproj
+++ b/src/Barcode.Generator.Tests/Barcode.Generator.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Barcode.Generator\Barcode.Generator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Barcode.Generator.Tests/BarcodeGeneratorTests.cs
+++ b/src/Barcode.Generator.Tests/BarcodeGeneratorTests.cs
@@ -1,0 +1,33 @@
+using Barcode.Generator;
+using Barcode.Generator.Rendering;
+using Xunit;
+
+namespace Barcode.Generator.Tests
+{
+    public class BarcodeGeneratorTests
+    {
+        [Fact]
+        public void BarcodeWriterPixelData_Produces_PixelData()
+        {
+            var writer = new BarcodeWriterPixelData { Format = BarcodeFormat.QR_CODE };
+            var pixelData = writer.Write("Hello World");
+
+            Assert.NotNull(pixelData);
+            Assert.NotEmpty(pixelData.Pixels);
+            Assert.True(pixelData.Width > 0);
+            Assert.True(pixelData.Height > 0);
+        }
+
+        [Fact]
+        public void BitmapConverter_FromPixelData_CorrectLength()
+        {
+            var writer = new BarcodeWriterPixelData { Format = BarcodeFormat.QR_CODE };
+            var pixelData = writer.Write("LengthTest");
+
+            var bmpBytes = BitmapConverter.FromPixelData(pixelData);
+
+            var expectedLength = 14 + 40 + pixelData.Width * pixelData.Height * 4;
+            Assert.Equal(expectedLength, bmpBytes.Length);
+        }
+    }
+}

--- a/src/Barcode.Generator.sln
+++ b/src/Barcode.Generator.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Barcode.Generator", "Barcod
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Demo.Console", "Demo.Console\Demo.Console.csproj", "{4C5514A4-03F2-4F3C-B92C-61FD35551B8D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Barcode.Generator.Tests", "Barcode.Generator.Tests\Barcode.Generator.Tests.csproj", "{B4001B4F-6DFB-4C8B-9E5B-D10B5D92F5CC}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{546DFC8C-3FE0-49A7-86C0-AF5202A93A34}"
 	ProjectSection(SolutionItems) = preProject
 		..\Build master.yml = ..\Build master.yml
@@ -23,11 +25,15 @@ Global
 		{E44649D2-52F6-4423-A9D7-9083BE3179A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E44649D2-52F6-4423-A9D7-9083BE3179A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E44649D2-52F6-4423-A9D7-9083BE3179A0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4C5514A4-03F2-4F3C-B92C-61FD35551B8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4C5514A4-03F2-4F3C-B92C-61FD35551B8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4C5514A4-03F2-4F3C-B92C-61FD35551B8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4C5514A4-03F2-4F3C-B92C-61FD35551B8D}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {4C5514A4-03F2-4F3C-B92C-61FD35551B8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {4C5514A4-03F2-4F3C-B92C-61FD35551B8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {4C5514A4-03F2-4F3C-B92C-61FD35551B8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {4C5514A4-03F2-4F3C-B92C-61FD35551B8D}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B4001B4F-6DFB-4C8B-9E5B-D10B5D92F5CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B4001B4F-6DFB-4C8B-9E5B-D10B5D92F5CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B4001B4F-6DFB-4C8B-9E5B-D10B5D92F5CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B4001B4F-6DFB-4C8B-9E5B-D10B5D92F5CC}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add xUnit project for tests
- add basic tests for barcode generation and bitmap conversion
- update solution to include new test project
- document running tests in README

## Testing
- `dotnet test src/Barcode.Generator.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd4b697b883308d5b5a1522786f23